### PR TITLE
typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ cd build
 cmake $SRCDIR
 ~~~
 
-This will download the required software needed for the project (see the [hunter docs][hunterdoc] for more information). You may see some warning while the system is compiling _HDF5_, which you can ignore. Once CMake has been run, a `Makefile` is generated so you can then perform `make` to buidl the project.
+This will download the required software needed for the project (see the [hunter docs][hunterdoc] for more information). You may see some warning while the system is compiling _HDF5_, which you can ignore. Once CMake has been run, a `Makefile` is generated so you can then perform `make` to build the project.
 
 ~~~{.sh}
 make
@@ -74,7 +74,7 @@ the `batch_size` must match the size of the dataset. If `batch_size` is unspecif
 
 ## How to Test
 
-Test your implementation with small batch size frist to verify the correctness. You can parse the `data/test100.hdf5` into smaller chuncks using your preferred language(e.g. python). 2, 10 and 100 queries are provides in `data/test2.hdf5`, `data/test10.hdf5` and `data/test100.hdf5` in the data folder. Maker sure the data file you feed in has the same batch size as the `batch_size` you specify in the command line.
+Test your implementation with small batch size first to verify the correctness. You can parse the `data/test100.hdf5` into smaller chuncks using your preferred language(e.g. python). 2, 10 and 100 queries are provides in `data/test2.hdf5`, `data/test10.hdf5` and `data/test100.hdf5` in the data folder. Maker sure the data file you feed in has the same batch size as the `batch_size` you specify in the command line.
 
 ~~~{.sh}
 ./ece408 ../data/test10.hdf5 ../data/model.hdf5 10


### PR DESCRIPTION
misspelt build in the hunter package manager section,
also misspelt first in the testing your code section